### PR TITLE
README の強調表示に GitHub Markdown を適用する

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## Notice: About this fork
-本レポジトリは fork 元である [google/accompanist](https://github.com/google/accompanist) において非推奨となる API を保持することを目的としています。
-動作、問題の解決やメンテナンスなどは一切保証しません。
-バージョンは [v0.33.2-alpha](https://github.com/google/accompanist/releases/tag/v0.33.2-alpha) を用いています。
+> [!Note]
+> 本レポジトリは fork 元である [google/accompanist](https://github.com/google/accompanist) において非推奨となる API を保持することを目的としています。
+> 動作、問題の解決やメンテナンスなどは一切保証しません。
+> バージョンは [v0.33.2-alpha](https://github.com/google/accompanist/releases/tag/v0.33.2-alpha) を用いています。
 
 ![Accompanist logo](docs/header.png)
 


### PR DESCRIPTION
Note 以外にも種類があるので、もし別のが適切であればフィードバックもらえたらと思います

- https://github.com/orgs/community/discussions/16925

| before | after |
| -- | -- |
<img width="854" alt="スクリーンショット 2024-01-18 10 39 40" src="https://github.com/yumemi-inc/accompanist/assets/5770480/c3160483-bc65-40f5-ab01-a8e34802935d"> | <img width="1030" alt="スクリーンショット 2024-01-18 10 39 29" src="https://github.com/yumemi-inc/accompanist/assets/5770480/e09cb744-d8e2-4bd9-8750-8a6b9f941ab4">
